### PR TITLE
VADNAST-28 -- User should be able to use pagination to navigate between `Older`/`Newer` pages

### DIFF
--- a/e2e/src/commonFunctions.ts
+++ b/e2e/src/commonFunctions.ts
@@ -31,3 +31,8 @@ export async function verifyLinksResponse(linksUrls: Set<string>): Promise<void>
         expect.soft(isSuccessful).toBeTruthy();
     }
 }
+
+export async function getHrefFromLink(locator: Locator): Promise<null | string> {
+    const href = await locator.getAttribute('href');
+    return href;
+}

--- a/e2e/src/components/Pagination.ts
+++ b/e2e/src/components/Pagination.ts
@@ -3,7 +3,6 @@ import BaseComponent from '../base/BaseComponent';
 
 export default class Pagination extends BaseComponent {
     private readonly paginationLocator = this.page.locator('nav.pager');
-    private readonly paginationButtonLocator = this.page.locator('nav.pager a');
     private readonly olderButtonLocator = this.page.locator('nav.pager a.next');
     private readonly newerButtonLocator = this.page.locator('nav.pager a.previous');
 
@@ -24,7 +23,7 @@ export default class Pagination extends BaseComponent {
     }
 
     public async clickOnOlderButton(): Promise<void> {
-        await this.paginationButtonLocator.click();
+        await this.olderButtonLocator.click();
     }
 
     public async clickOnNewerButton(): Promise<void> {

--- a/e2e/src/components/Pagination.ts
+++ b/e2e/src/components/Pagination.ts
@@ -23,11 +23,11 @@ export default class Pagination extends BaseComponent {
         return this.newerButtonLocator;
     }
 
-    public async clickOlderButton(): Promise<void> {
+    public async clickOnOlderButton(): Promise<void> {
         await this.paginationButtonLocator.click();
     }
 
-    public async clickNewerButton(): Promise<void> {
+    public async clickOnNewerButton(): Promise<void> {
         await this.newerButtonLocator.click();
     }
 }

--- a/e2e/src/components/Pagination.ts
+++ b/e2e/src/components/Pagination.ts
@@ -1,0 +1,33 @@
+import { Page, Locator } from '@playwright/test';
+import BaseComponent from '../base/BaseComponent';
+
+export default class Pagination extends BaseComponent {
+    private readonly paginationLocator = this.page.locator('nav.pager');
+    private readonly paginationButtonLocator = this.page.locator('nav.pager a');
+    private readonly olderButtonLocator = this.page.locator('nav.pager a.next');
+    private readonly newerButtonLocator = this.page.locator('nav.pager a.previous');
+
+    constructor(page: Page) {
+        super(page);
+    }
+
+    get paginationSection(): Locator {
+        return this.paginationLocator;
+    }
+
+    get olderButton(): Locator {
+        return this.olderButtonLocator;
+    }
+
+    get newerButton(): Locator {
+        return this.newerButtonLocator;
+    }
+
+    public async clickOlderButton(): Promise<void> {
+        await this.paginationButtonLocator.click();
+    }
+
+    public async clickNewerButton(): Promise<void> {
+        await this.newerButtonLocator.click();
+    }
+}

--- a/e2e/src/components/PostsPreview.ts
+++ b/e2e/src/components/PostsPreview.ts
@@ -15,6 +15,14 @@ export default class PostsPreview extends BaseComponent {
         super(page);
     }
 
+    get allPosts(): Locator {
+        return this.postLocator;
+    }
+
+    get allReadMoreLinks(): Locator {
+        return this.page.locator('.read-more');
+    }
+
     public async getLatestPost(): Promise<Locator> {
         return this.postLocator.nth(0);
     }
@@ -73,14 +81,6 @@ export default class PostsPreview extends BaseComponent {
         const getPreviewReadTime = await this.readTime();
         const readTime = await getPreviewReadTime.innerText();
         return readTime;
-    }
-
-    get allPosts(): Locator {
-        return this.postLocator;
-    }
-
-    get allReadMoreLinks(): Locator {
-        return this.page.locator('.read-more');
     }
 
     public async getAllPosts(): Promise<Locator[]> {

--- a/e2e/src/pages/HomePage.ts
+++ b/e2e/src/pages/HomePage.ts
@@ -4,12 +4,14 @@ import PostsPreview from '../components/PostsPreview';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 import SideMenu from '../components/SideMenu';
+import Pagination from '../components/Pagination';
 
 export default class HomePage extends BasePage {
     public postsPreview: PostsPreview;
     public footer: Footer;
     public header: Header;
     public sideMenu: SideMenu;
+    public pagination: Pagination;
 
     constructor(page: Page) {
         super(page, 'Home Page', '');
@@ -17,5 +19,6 @@ export default class HomePage extends BasePage {
         this.footer = new Footer(page);
         this.header = new Header(page);
         this.sideMenu = new SideMenu(page);
+        this.pagination = new Pagination(page);
     }
 }

--- a/e2e/tests/paginationCheck.spec.ts
+++ b/e2e/tests/paginationCheck.spec.ts
@@ -12,12 +12,12 @@ test.describe('Pagination Functionality', () => {
         await homePage.pagination.olderButton.isVisible();
 
         const olderButtonUrl = await getHrefFromLink(homePage.pagination.olderButton);
-        await homePage.pagination.clickOlderButton();
+        await homePage.pagination.clickOnOlderButton();
         await elementsAreVisible(homePage.postsPreview.allPosts);
         expect(olderButtonUrl).not.toBe(await getHrefFromLink(homePage.pagination.newerButton));
 
         await homePage.pagination.newerButton.isVisible();
-        await homePage.pagination.clickNewerButton();
+        await homePage.pagination.clickOnNewerButton();
         await elementsAreVisible(homePage.postsPreview.allPosts);
         expect(page.url()).toContain(await homePage.getPageUrl());
     });

--- a/e2e/tests/paginationCheck.spec.ts
+++ b/e2e/tests/paginationCheck.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '../src/FixtureConfigs';
+import { elementsAreVisible, getHrefFromLink } from '../src/commonFunctions';
+
+test.describe('Pagination Functionality', () => {
+    test('Verify pagination controls and navigation', {
+        tag: '@regression'
+    }, async ({ page, homePage }) => {
+        await homePage.openAndVerify();
+
+        await elementsAreVisible(homePage.postsPreview.allPosts);
+        await homePage.pagination.paginationSection.isVisible();
+        await homePage.pagination.olderButton.isVisible();
+
+        const olderButtonUrl = await getHrefFromLink(homePage.pagination.olderButton);
+        await homePage.pagination.clickOlderButton();
+        await elementsAreVisible(homePage.postsPreview.allPosts);
+        expect(olderButtonUrl).not.toBe(await getHrefFromLink(homePage.pagination.newerButton));
+
+        await homePage.pagination.newerButton.isVisible();
+        await homePage.pagination.clickNewerButton();
+        await elementsAreVisible(homePage.postsPreview.allPosts);
+        expect(page.url()).toContain(await homePage.getPageUrl());
+    });
+});


### PR DESCRIPTION
The user is at the home page and scrolls down to the pagination component. He clicks the 'Older' button and sees that the page navigates to the older posts and makes sure that the page differs from the original one. The user clicks the 'Newer' button after navigating to older posts. The page navigates back to display newer posts and provides the original link. 