### PR TITLE
Fix side menu tests

### DIFF
--- a/e2e/tests/sideMenu.spec.ts
+++ b/e2e/tests/sideMenu.spec.ts
@@ -26,7 +26,7 @@ test.describe('Side Menu', () => {
       await homePage.open();
 
       await homePage.header.clickOnBurgerMenu();
-      await homePage.sideMenu.container.isVisible();
+      await expect(homePage.sideMenu.container).toBeVisible();
       await expect(homePage.sideMenu.links).areVisible();
 
       const linksUrls = await utils.getLinks(
@@ -46,7 +46,7 @@ test.describe('Side Menu', () => {
       await aboutPage.open();
 
       await aboutPage.header.clickOnBurgerMenu();
-      await aboutPage.sideMenu.container.isVisible();
+      await expect(aboutPage.sideMenu.container).toBeVisible();
 
       const homeLink = await aboutPage.sideMenu.getLinkByText('Home');
       await homeLink.click();


### PR DESCRIPTION
**Summary**
This PR fixes the [issue](https://github.com/VadimNastoyashchy/vadimnastoyashchy.github.io/issues/200) related to the incorrect use of the `isVisible()` method in the **Side Menu** tests.

**Changes**
- Replaced the `isVisible()` method with the `expect(...).toBeVisible()` assetion in two tests.

**Test results for the modified tests**:
<img width="995" height="380" alt="results" src="https://github.com/user-attachments/assets/b9267b1f-5c82-4614-9f7d-c096ada06d3c" />

